### PR TITLE
Accept Arrayable as props for modals

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Inertia {
     /**
-     * @method \Momentum\Modal\Modal modal(string $component, array $props = [])
-     * @method \Momentum\Modal\Modal dialog(string $component, array $props = [])
+     * @method \Momentum\Modal\Modal modal(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
+     * @method \Momentum\Modal\Modal dialog(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
      */
     class ResponseFactory
     {
@@ -19,8 +19,8 @@ namespace Inertia {
     }
 
     /**
-     * @method static \Momentum\Modal\Modal modal(string $component, array $props = [])
-     * @method static \Momentum\Modal\Modal dialog(string $component, array $props = [])
+     * @method static \Momentum\Modal\Modal modal(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
+     * @method static \Momentum\Modal\Modal dialog(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
      */
     class Inertia
     {

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Momentum\Modal;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -16,7 +17,7 @@ class Modal implements Responsable
 
     public function __construct(
         protected string $component,
-        protected array $props = []
+        protected array|Arrayable $props = []
     ) {
     }
 

--- a/src/ModalServiceProvider.php
+++ b/src/ModalServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Momentum\Modal;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\ServiceProvider;
 use Inertia\Response;
 use Inertia\ResponseFactory;
@@ -14,7 +15,7 @@ class ModalServiceProvider extends ServiceProvider
     {
         ResponseFactory::macro('modal', function (
             string $component,
-            array $props = []
+            array|Arrayable $props = []
         ) {
             return new Modal($component, $props);
         });
@@ -29,7 +30,7 @@ class ModalServiceProvider extends ServiceProvider
     {
         ResponseFactory::macro('dialog', function (
             string $component,
-            array $props = []
+            array|Arrayable $props = []
         ) {
             return new Modal($component, $props);
         });


### PR DESCRIPTION
In Inertia you can pass an `Arrayable` object as props, which is useful if you use something like `spatie/laravel-data` since you don't have to convert the data objects to array yourself. This PR updates this package to also accept `Arrayable` objects as props.