### PR TITLE
feat: add support for lazy props in modals

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -14,11 +14,13 @@ use Illuminate\Support\Str;
 class Modal implements Responsable
 {
     protected string $baseURL;
+    protected array $props = [];
 
     public function __construct(
         protected string $component,
-        protected array|Arrayable $props = []
+        array|Arrayable $props
     ) {
+        $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
     }
 
     public function baseRoute(string $name, mixed $parameters = [], bool $absolute = true): static

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -20,7 +20,7 @@ class Modal implements Responsable
         protected string $component,
         array|Arrayable $props
     ) {
-        $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
+        $this->with($props);
     }
 
     public function baseRoute(string $name, mixed $parameters = [], bool $absolute = true): static
@@ -35,9 +35,9 @@ class Modal implements Responsable
         return $this->baseRoute($name, $parameters, $absolute);
     }
 
-    public function with(array $props): static
+    public function with(array|Arrayable $props): static
     {
-        $this->props = $props;
+        $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
 
         return $this;
     }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -42,8 +42,12 @@ class Modal implements Responsable
 
     public function render(): mixed
     {
+        $flatProps = [];
+        foreach ($this->props as $key => $prop) {
+            $flatProps['modal.props.'.$key] = $prop;
+        }
         /** @phpstan-ignore-next-line */
-        inertia()->share(['modal' => $this->component()]);
+        inertia()->share(['modal' => $this->component(), ...$flatProps]);
 
         // render background component on first visit
         if (request()->header('X-Inertia') && request()->header('X-Inertia-Partial-Component')) {
@@ -100,8 +104,7 @@ class Modal implements Responsable
             'component' => $this->component,
             'baseURL' => $this->baseURL,
             'redirectURL' => $this->redirectURL(),
-            'props' => $this->props,
-            'key' => request()->header('X-Inertia-Modal-Key', Str::uuid()->toString()),
+            'key' => request()->header('X-Inertia-Modal-Key') ?? Str::uuid()->toString(),
             'nonce' => Str::uuid()->toString(),
         ];
     }


### PR DESCRIPTION
Inertia doesn't support lazyness for nested props because it only does a simple `array_filter`, but it has a magic trick up it's sleeve that unpacks string props with dots in them after the `array_filter` has been done https://github.com/inertiajs/inertia-laravel/blob/master/src/Response.php#L148 

We can use that and share a flat array of modal props to inertia which will enable the lazy prop feature by using `only: ['modal.props.someProp']`

This PR needs https://github.com/lepikhinb/momentum-modal-plugin/pull/4 to work properly

Fixes: #13 


Props can go back to their unflattened form when https://github.com/inertiajs/inertia-laravel/pull/435 is released