### PR TITLE
add option to force base url

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -15,6 +15,8 @@ class Modal implements Responsable
 {
     protected string $baseURL;
 
+    protected bool $forceBase = false;
+
     public function __construct(
         protected string $component,
         protected array|Arrayable $props = []
@@ -36,6 +38,13 @@ class Modal implements Responsable
     public function baseURL(string $url): static
     {
         $this->baseURL = $url;
+
+        return $this;
+    }
+
+    public function forceBase(bool $force = true): static
+    {
+        $this->forceBase = $force;
 
         return $this;
     }
@@ -122,7 +131,7 @@ class Modal implements Responsable
 
         $referer = request()->headers->get('referer');
 
-        if (request()->header('X-Inertia') && $referer && $referer != url()->current()) {
+        if (request()->header('X-Inertia') && $referer && $referer != url()->current() && ! $this->forceBase) {
             return $referer;
         }
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -124,6 +124,10 @@ class Modal implements Responsable
 
     protected function redirectURL(): string
     {
+        if ($this->forceBase) {
+            return $this->baseURL;
+        }
+    
         if (request()->header('X-Inertia-Modal-Redirect')) {
             /** @phpstan-ignore-next-line */
             return request()->header('X-Inertia-Modal-Redirect');
@@ -131,7 +135,7 @@ class Modal implements Responsable
 
         $referer = request()->headers->get('referer');
 
-        if (request()->header('X-Inertia') && $referer && $referer != url()->current() && ! $this->forceBase) {
+        if (request()->header('X-Inertia') && $referer && $referer != url()->current()) {
             return $referer;
         }
 


### PR DESCRIPTION
Currently the `baseUrl` option is only working as a fallback option i.e. when the modal url is accessed directly from the browser's address bar.

This PR adds an option to force the base page to render even if the request is an inertia request (my use case is for a page that is protected by the auth middleware but the modal is not).

Usage:
```php
return Inertia::modal('Tweets/Show')
            ->baseRoute('tweets.index')
            ->forceBase();

// or pass in a boolean

$shouldForce = request()->header('referer') !== 'https://example.com/tweets/create';

return Inertia::modal('Tweets/Show')
            ->baseRoute('tweets.index')
            ->forceBase($shouldForce);
```