### PR TITLE
Allow swapping the modal implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ class ShowTweet extends Controller
 
 Find the example frontend implementation [here](https://github.com/lepikhinb/momentum-modal-plugin/tree/master/examples).
 
+### Using a custom Modal class
+
+If you need to customize the Modal class - for example, to tweak the modal response - you can do so by binding a different implementation to the service container:
+
+```php
+class CustomModal extends Momentum\Modal\Modal
+{
+    public function render($component, $props = [])
+    {
+        return parent::render($component, $props)
+            ->withViewData(['foo' => 'bar']);
+    }
+}
+
+app()->bind(Momentum\Modal\Modal::class, CustomModal::class);
+```
+
 ## Advanced Inertia
 
 [<img src="https://advanced-inertia.com/og.png" width="420px" />](https://advanced-inertia.com)

--- a/src/ModalServiceProvider.php
+++ b/src/ModalServiceProvider.php
@@ -17,7 +17,7 @@ class ModalServiceProvider extends ServiceProvider
             string $component,
             array|Arrayable $props = []
         ) {
-            return new Modal($component, $props);
+            return app()->makeWith(Modal::class, compact('component', 'props'));
         });
 
         $this->registerCompatibilityMacros();
@@ -32,12 +32,14 @@ class ModalServiceProvider extends ServiceProvider
             string $component,
             array|Arrayable $props = []
         ) {
-            return new Modal($component, $props);
+            return app()->makeWith(Modal::class, compact('component', 'props'));
         });
 
         Response::macro('stackable', function () {
-            /** @phpstan-ignore-next-line */
-            return new Modal($this->component, $this->props);
+            return app()->makeWith(Modal::class, [
+                'component' => $this->component,
+                'props' => $this->props,
+            ]);
         });
     }
 }

--- a/tests/Pest/ModalTest.php
+++ b/tests/Pest/ModalTest.php
@@ -118,3 +118,16 @@ test('route parameters are bound correctly', function () {
                 ->where('modal.baseURL', route('users.show', $otherUser));
         });
 });
+
+test('modal implementation can be swapped via service container', function () {
+	$user = user();
+	$tweet = tweet($user);
+
+	$this->app->bind(Momentum\Modal\Modal::class, Momentum\Modal\Tests\Stubs\ExampleModal::class);
+
+	get(route('users.tweets.show', [$user, $tweet]))
+		->assertSuccessful()
+		->assertInertia(function (AssertableInertia $page) {
+			$page->component('Users/Show')->where('modal.foo', 'bar');
+		});
+});

--- a/tests/Stubs/ExampleModal.php
+++ b/tests/Stubs/ExampleModal.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Momentum\Modal\Tests\Stubs;
+
+use Momentum\Modal\Modal;
+
+class ExampleModal extends Modal {
+	protected function component(): array
+	{
+		return [
+			'foo' => 'bar',
+			...parent::component(),
+		];
+	}
+}


### PR DESCRIPTION
This PR leverages the Laravel Service Container to create new instances of the `Modal` class. This allows developers to customize the Modal class by binding their own implementation to the container.

A concrete use case is to customize the `Modal::handleRoute` method to add additional middleware to the base route. For example, I need to forget a specific route parameter after a middleware runs, but by default Momentum Modal does not apply middleware to the base route at all (except for resolving the route parameters).

This change will not affect existing usage at all, but will make it easier (possible) to extend the existing functionality.

